### PR TITLE
support for study variable group and fix previous implementation

### DIFF
--- a/api/src/main/java/org/lifstools/mztab2/model/StudyVariable.java
+++ b/api/src/main/java/org/lifstools/mztab2/model/StudyVariable.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.lifstools.mztab2.model.Assay;
 import org.lifstools.mztab2.model.Parameter;
-import org.lifstools.mztab2.model.StudyVariableGroup;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import jakarta.validation.constraints.*;
@@ -40,7 +39,6 @@ import org.hibernate.validator.constraints.*;
   StudyVariable.JSON_PROPERTY_ID,
   StudyVariable.JSON_PROPERTY_NAME,
   StudyVariable.JSON_PROPERTY_ASSAY_REFS,
-  StudyVariable.JSON_PROPERTY_GROUP_REF,
   StudyVariable.JSON_PROPERTY_AVERAGE_FUNCTION,
   StudyVariable.JSON_PROPERTY_VARIATION_FUNCTION,
   StudyVariable.JSON_PROPERTY_DESCRIPTION
@@ -58,10 +56,6 @@ public class StudyVariable {
   public static final String JSON_PROPERTY_ASSAY_REFS = "assay_refs";
   @jakarta.annotation.Nullable
   private List<@Valid Assay> assayRefs = new ArrayList<>();
-
-  public static final String JSON_PROPERTY_GROUP_REF = "group_ref";
-  @jakarta.annotation.Nullable
-  private StudyVariableGroup groupRef;
 
   public static final String JSON_PROPERTY_AVERAGE_FUNCTION = "average_function";
   @jakarta.annotation.Nullable
@@ -168,33 +162,6 @@ public class StudyVariable {
     this.assayRefs = assayRefs;
   }
 
-  public StudyVariable groupRef(@jakarta.annotation.Nullable StudyVariableGroup groupRef) {
-    
-    this.groupRef = groupRef;
-    return this;
-  }
-
-  /**
-   * Reference to the study_variable_group that this study variable belongs to. This field is mandatory if study_variable_group(s) are defined.
-   * @return groupRef
-   */
-  @jakarta.annotation.Nullable
-  @Valid
-
-  @JsonProperty(value = JSON_PROPERTY_GROUP_REF, required = false)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
-  public StudyVariableGroup getGroupRef() {
-    return groupRef;
-  }
-
-
-  @JsonProperty(value = JSON_PROPERTY_GROUP_REF, required = false)
-  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setGroupRef(@jakarta.annotation.Nullable StudyVariableGroup groupRef) {
-    this.groupRef = groupRef;
-  }
-
   public StudyVariable averageFunction(@jakarta.annotation.Nullable Parameter averageFunction) {
     
     this.averageFunction = averageFunction;
@@ -288,7 +255,6 @@ public class StudyVariable {
     return Objects.equals(this.id, studyVariable.id) &&
         Objects.equals(this.name, studyVariable.name) &&
         Objects.equals(this.assayRefs, studyVariable.assayRefs) &&
-        Objects.equals(this.groupRef, studyVariable.groupRef) &&
         Objects.equals(this.averageFunction, studyVariable.averageFunction) &&
         Objects.equals(this.variationFunction, studyVariable.variationFunction) &&
         Objects.equals(this.description, studyVariable.description);
@@ -296,7 +262,7 @@ public class StudyVariable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, assayRefs, groupRef, averageFunction, variationFunction, description);
+    return Objects.hash(id, name, assayRefs, averageFunction, variationFunction, description);
   }
 
   @Override
@@ -306,7 +272,6 @@ public class StudyVariable {
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    assayRefs: ").append(toIndentedString(assayRefs)).append("\n");
-    sb.append("    groupRef: ").append(toIndentedString(groupRef)).append("\n");
     sb.append("    averageFunction: ").append(toIndentedString(averageFunction)).append("\n");
     sb.append("    variationFunction: ").append(toIndentedString(variationFunction)).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");

--- a/api/src/main/java/org/lifstools/mztab2/model/StudyVariableGroup.java
+++ b/api/src/main/java/org/lifstools/mztab2/model/StudyVariableGroup.java
@@ -15,6 +15,8 @@ package org.lifstools.mztab2.model;
 
 import java.util.Objects;
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -37,7 +39,8 @@ import org.hibernate.validator.constraints.*;
   StudyVariableGroup.JSON_PROPERTY_DESCRIPTION,
   StudyVariableGroup.JSON_PROPERTY_TYPE,
   StudyVariableGroup.JSON_PROPERTY_DATATYPE,
-  StudyVariableGroup.JSON_PROPERTY_UNIT
+  StudyVariableGroup.JSON_PROPERTY_UNIT,
+  StudyVariableGroup.JSON_PROPERTY_STUDY_VARIABLE_REFS
 })
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-04-29T15:34:38.183974+02:00[Europe/Berlin]", comments = "Generator version: 7.17.0")
 public class StudyVariableGroup {
@@ -64,6 +67,10 @@ public class StudyVariableGroup {
   public static final String JSON_PROPERTY_UNIT = "unit";
   @jakarta.annotation.Nullable
   private Parameter unit;
+
+  public static final String JSON_PROPERTY_STUDY_VARIABLE_REFS = "study_variable_refs";
+  @jakarta.annotation.Nullable
+  private List<@Valid StudyVariable> studyVariableRefs = new ArrayList<>();
 
   public StudyVariableGroup() {
   }
@@ -231,6 +238,41 @@ public class StudyVariableGroup {
     this.unit = unit;
   }
 
+  public StudyVariableGroup studyVariableRefs(@jakarta.annotation.Nullable List<@Valid StudyVariable> studyVariableRefs) {
+
+    this.studyVariableRefs = studyVariableRefs;
+    return this;
+  }
+
+  public StudyVariableGroup addStudyVariableRefsItem(StudyVariable studyVariableRefsItem) {
+    if (this.studyVariableRefs == null) {
+      this.studyVariableRefs = new ArrayList<>();
+    }
+    this.studyVariableRefs.add(studyVariableRefsItem);
+    return this;
+  }
+
+  /**
+   * The study variables that belong to this study variable group.
+   * @return studyVariableRefs
+   */
+  @jakarta.annotation.Nullable
+  @Valid
+
+  @JsonProperty(value = JSON_PROPERTY_STUDY_VARIABLE_REFS, required = false)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+
+  public List<@Valid StudyVariable> getStudyVariableRefs() {
+    return studyVariableRefs;
+  }
+
+
+  @JsonProperty(value = JSON_PROPERTY_STUDY_VARIABLE_REFS, required = false)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setStudyVariableRefs(@jakarta.annotation.Nullable List<@Valid StudyVariable> studyVariableRefs) {
+    this.studyVariableRefs = studyVariableRefs;
+  }
+
 
   @Override
   public boolean equals(Object o) {
@@ -246,12 +288,13 @@ public class StudyVariableGroup {
         Objects.equals(this.description, studyVariableGroup.description) &&
         Objects.equals(this.type, studyVariableGroup.type) &&
         Objects.equals(this.datatype, studyVariableGroup.datatype) &&
-        Objects.equals(this.unit, studyVariableGroup.unit);
+        Objects.equals(this.unit, studyVariableGroup.unit) &&
+        Objects.equals(this.studyVariableRefs, studyVariableGroup.studyVariableRefs);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, parameter, description, type, datatype, unit);
+    return Objects.hash(id, parameter, description, type, datatype, unit, studyVariableRefs);
   }
 
   @Override
@@ -264,6 +307,7 @@ public class StudyVariableGroup {
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    datatype: ").append(toIndentedString(datatype)).append("\n");
     sb.append("    unit: ").append(toIndentedString(unit)).append("\n");
+    sb.append("    studyVariableRefs: ").append(toIndentedString(studyVariableRefs)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/api/src/main/resources/mzTab_m_openapi.yml
+++ b/api/src/main/resources/mzTab_m_openapi.yml
@@ -692,6 +692,8 @@ components:
             datatype: The datatype of the group variable, used to disambiguate how the associated values are encoded and parsed. Optional, but producers SHOULD provide it to simplify interpretation by downstream consumers. Supported values are xsd:string, xsd:integer, xsd:decimal, xsd:boolean, xsd:date, xsd:time, xsd:dateTime, and xsd:anyURI.
 
             unit: An optional parameter specifying the unit of the study variable group.
+
+            study_variable_refs: Bar-separated references to the study variables that belong to this group.
           default: []
           items:
             $ref: "#/components/schemas/StudyVariableGroup"
@@ -704,6 +706,8 @@ components:
 
             MTD	study_variable_group[1]-datatype	xsd:string
 
+            MTD	study_variable_group[1]-study_variable_refs	study_variable[1]| study_variable[2]
+
             MTD	study_variable_group[2]	[,,timepoint,]
 
             MTD	study_variable_group[2]-description	Time after treatment
@@ -713,6 +717,8 @@ components:
             MTD	study_variable_group[2]-datatype	xsd:integer
 
             MTD	study_variable_group[2]-unit	[UO, UO:0000033, day, ]
+
+            MTD	study_variable_group[2]-study_variable_refs	study_variable[3]| study_variable[4]| study_variable[5]
         study_variable:
           type: array
           description: >
@@ -2139,9 +2145,6 @@ components:
           items:
             $ref: "#/components/schemas/Assay"
           description: The assays referenced by this study variable.
-        group_ref:
-          $ref: "#/components/schemas/StudyVariableGroup"
-          description: Reference to the study_variable_group that this study variable belongs to. This field is mandatory if study_variable_group(s) are defined.
         average_function:
           $ref: "#/components/schemas/Parameter"
         variation_function:
@@ -2162,6 +2165,8 @@ components:
         datatype: The datatype of the group variable, used to disambiguate how the associated values are encoded and parsed. Optional, but producers SHOULD provide it to simplify interpretation by downstream consumers. Supported values are xsd:string, xsd:integer, xsd:decimal, xsd:boolean, xsd:date, xsd:time, xsd:dateTime, and xsd:anyURI. Date, time and dateTime values MUST be encoded in ISO 8601 format.
 
         unit: An optional parameter specifying the unit of the study variable group (e.g., day, hour, concentration, etc.).
+
+        study_variable_refs: Bar-separated references to the study variables that belong to this group. Every group MUST reference at least one study variable, and every study variable MUST be referenced by exactly one group when study variable groups are defined.
       x-mztab-example: >
         MTD	study_variable_group[1]	[PATO, PATO:0000383, sex, ]
 
@@ -2170,6 +2175,8 @@ components:
         MTD	study_variable_group[1]-type	[STATO, STATO:0000252, categorical variable, ]
 
         MTD	study_variable_group[1]-datatype	xsd:string
+
+        MTD	study_variable_group[1]-study_variable_refs	study_variable[1]| study_variable[2]
 
         MTD	study_variable_group[2]	[PATO, PATO:0000384, timepoint, ]
 
@@ -2181,15 +2188,13 @@ components:
 
         MTD	study_variable_group[2]-unit	[UO, UO:0000033, day, ]
 
-        MTD	study_variable[1]	Female_0day
+        MTD	study_variable_group[2]-study_variable_refs	study_variable[3]| study_variable[4]| study_variable[5]
 
-        MTD	study_variable[1]-group_ref	study_variable_group[1]
+        MTD	study_variable[1]	Female
 
         MTD	study_variable[1]-assay_refs	assay[1]| assay[2]| assay[3]
 
-        MTD	study_variable[2]	Female_1day
-
-        MTD	study_variable[2]-group_ref	study_variable_group[2]
+        MTD	study_variable[2]	Male
 
         MTD	study_variable[2]-assay_refs	assay[4]| assay[5]| assay[6]
       x-mztab-serialize-by-id: "true"
@@ -2227,6 +2232,12 @@ components:
         unit:
           $ref: "#/components/schemas/Parameter"
           description: An optional parameter specifying the unit of the study variable group (e.g., day, hour, concentration, etc.).
+        study_variable_refs:
+          type: array
+          default: []
+          items:
+            $ref: "#/components/schemas/StudyVariable"
+          description: The study variables that belong to this study variable group.
     Assay:
       description: >
         Specification of assay.

--- a/io/src/main/java/org/lifstools/mztab2/io/serialization/StudyVariableGroupSerializer.java
+++ b/io/src/main/java/org/lifstools/mztab2/io/serialization/StudyVariableGroupSerializer.java
@@ -22,8 +22,15 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import static org.lifstools.mztab2.io.serialization.Serializers.addLineWithProperty;
+import static org.lifstools.mztab2.io.serialization.Serializers.addSubElementStrings;
+import org.lifstools.mztab2.model.Metadata;
+import org.lifstools.mztab2.model.StudyVariable;
 import org.lifstools.mztab2.model.StudyVariableGroup;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import uk.ac.ebi.pride.jmztab2.model.Section;
 
@@ -97,6 +104,25 @@ public class StudyVariableGroupSerializer extends StdSerializer<StudyVariableGro
             addLineWithProperty(jg, Section.Metadata.getPrefix(),
                 StudyVariableGroup.JSON_PROPERTY_UNIT,
                 studyVariableGroup, studyVariableGroup.getUnit());
+            // study_variable_refs as a bar-separated list of study_variable[id]
+            addSubElementStrings(jg, Section.Metadata.getPrefix(),
+                studyVariableGroup,
+                StudyVariableGroup.JSON_PROPERTY_STUDY_VARIABLE_REFS,
+                Optional.ofNullable(studyVariableGroup.getStudyVariableRefs()).
+                    orElse(Collections.emptyList()).
+                    stream().
+                    sorted(Comparator.comparing(StudyVariable::getId,
+                        Comparator.nullsFirst(Comparator.naturalOrder()))).
+                    map((svRef) ->
+                    {
+                        return new StringBuilder().
+                            append(Metadata.JSON_PROPERTY_STUDY_VARIABLE).
+                            append("[").
+                            append(svRef.getId()).
+                            append("]").
+                            toString();
+                    }).
+                    collect(Collectors.toList()), true);
         } else {
             log.debug(StudyVariableGroup.class.getSimpleName() + " is null!");
         }

--- a/io/src/main/java/org/lifstools/mztab2/io/validators/StudyVariableGroupValidator.java
+++ b/io/src/main/java/org/lifstools/mztab2/io/validators/StudyVariableGroupValidator.java
@@ -19,18 +19,20 @@ import org.lifstools.mztab2.model.Metadata;
 import org.lifstools.mztab2.model.StudyVariable;
 import org.lifstools.mztab2.model.StudyVariableGroup;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.SortedMap;
-import java.util.stream.Collectors;
 import uk.ac.ebi.pride.jmztab2.utils.errors.LogicalErrorType;
 import uk.ac.ebi.pride.jmztab2.utils.errors.MZTabError;
 import uk.ac.ebi.pride.jmztab2.utils.parser.MZTabParserContext;
 
 /**
- * Validates that each study_variable_group entry has the required fields and
- * that optional fields conform to spec constraints.
+ * Validates that each study_variable_group entry has the required fields, that
+ * optional fields conform to spec constraints, and that its study_variable_refs
+ * reference defined study variables. Once study variable groups are defined,
+ * every study variable MUST belong to exactly one group.
  *
  * @author nilshoffmann
  */
@@ -55,11 +57,8 @@ public class StudyVariableGroupValidator implements RefiningValidator<Metadata> 
             return errorList;
         }
 
-        Set<Integer> referencedGroupIds = svMap.values().stream()
-            .filter(sv -> sv.getGroupRef() != null
-                && sv.getGroupRef().getId() != null)
-            .map(sv -> sv.getGroupRef().getId())
-            .collect(Collectors.toSet());
+        // how often each study variable is referenced across all groups
+        Map<Integer, Integer> referenceCount = new HashMap<>();
 
         for (Integer id : svgMap.keySet()) {
             StudyVariableGroup svg = svgMap.get(id);
@@ -105,12 +104,48 @@ public class StudyVariableGroupValidator implements RefiningValidator<Metadata> 
                     + " (MUST be one of: " + String.join(", ", VALID_XSD_DATATYPES) + ")"));
             }
 
-            // every declared group must be referenced by at least one study variable
-            if (!referencedGroupIds.contains(id)) {
+            // every group MUST reference at least one study variable
+            List<StudyVariable> refs = svg.getStudyVariableRefs();
+            if (refs == null || refs.isEmpty()) {
+                errorList.add(new MZTabError(
+                    LogicalErrorType.NotDefineInMetadata, -1,
+                    Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[" + id + "]-"
+                    + StudyVariableGroup.JSON_PROPERTY_STUDY_VARIABLE_REFS));
+                continue;
+            }
+
+            // every referenced study variable MUST be defined; replace the id-only
+            // reference with the resolved study variable.
+            for (int i = 0; i < refs.size(); i++) {
+                Integer refId = refs.get(i).getId();
+                StudyVariable referenced = svMap.get(refId);
+                if (referenced == null) {
+                    errorList.add(new MZTabError(
+                        LogicalErrorType.NotDefineInMetadata, -1,
+                        Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[" + id + "]-"
+                        + StudyVariableGroup.JSON_PROPERTY_STUDY_VARIABLE_REFS
+                        + "\t" + Metadata.JSON_PROPERTY_STUDY_VARIABLE + "[" + refId + "]"));
+                } else {
+                    refs.set(i, referenced);
+                    referenceCount.merge(refId, 1, Integer::sum);
+                }
+            }
+        }
+
+        // once groups are defined, every study variable MUST belong to exactly
+        // one group.
+        for (Integer svId : svMap.keySet()) {
+            int count = referenceCount.getOrDefault(svId, 0);
+            if (count == 0) {
                 errorList.add(new MZTabError(
                     LogicalErrorType.StudyVariableNotDefined, -1,
-                    Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[" + id + "]"
-                    + " is not referenced by any study_variable[n]-group_ref"));
+                    Metadata.JSON_PROPERTY_STUDY_VARIABLE + "[" + svId + "]"
+                    + " is not referenced by any study_variable_group[n]-study_variable_refs"));
+            } else if (count > 1) {
+                errorList.add(new MZTabError(
+                    LogicalErrorType.DuplicationID, -1,
+                    Metadata.JSON_PROPERTY_STUDY_VARIABLE + "[" + svId + "]"
+                    + " is referenced by more than one study_variable_group"));
             }
         }
 

--- a/io/src/main/java/org/lifstools/mztab2/io/validators/StudyVariableValidator.java
+++ b/io/src/main/java/org/lifstools/mztab2/io/validators/StudyVariableValidator.java
@@ -42,6 +42,27 @@ public class StudyVariableValidator implements RefiningValidator<Metadata> {
             errorList.add(new MZTabError(
                     LogicalErrorType.SingleStudyVariableName, -1));
         } else {
+            // Resolve deferred assay_refs against the (now complete) assay map.
+            // Referenced assays may have been defined after the study variable.
+            for (StudyVariable sv : svMap.values()) {
+                if (sv == null || sv.getAssayRefs() == null) {
+                    continue;
+                }
+                List<Assay> refs = sv.getAssayRefs();
+                for (int i = 0; i < refs.size(); i++) {
+                    Integer refId = refs.get(i).getId();
+                    Assay resolved = assayMap.get(refId);
+                    if (resolved == null) {
+                        errorList.add(new MZTabError(
+                                LogicalErrorType.NotDefineInMetadata, -1,
+                                Metadata.JSON_PROPERTY_STUDY_VARIABLE + "[" + sv.getId() + "]-"
+                                + StudyVariable.JSON_PROPERTY_ASSAY_REFS
+                                + "\t" + Metadata.JSON_PROPERTY_ASSAY + "[" + refId + "]"));
+                    } else {
+                        refs.set(i, resolved);
+                    }
+                }
+            }
             if (svMap.size() == 1 && assayMap.size() > 0) {
                 StudyVariable sv = svMap.get(Integer.valueOf(1));
                 if (sv.getName() == null || sv.getName().isEmpty()) {

--- a/io/src/main/java/uk/ac/ebi/pride/jmztab2/model/MetadataProperty.java
+++ b/io/src/main/java/uk/ac/ebi/pride/jmztab2/model/MetadataProperty.java
@@ -71,12 +71,12 @@ public enum MetadataProperty {
     STUDY_VARIABLE_AVERAGE_FUNCTION       (MetadataElement.STUDY_VARIABLE,                      "average_function"),
     STUDY_VARIABLE_VARIATION_FUNCTION     (MetadataElement.STUDY_VARIABLE,                      "variation_function"),
     STUDY_VARIABLE_FACTORS                (MetadataElement.STUDY_VARIABLE,                      "factors"),
-    STUDY_VARIABLE_GROUP_REF              (MetadataElement.STUDY_VARIABLE,                      "group_ref"),
 
     STUDY_VARIABLE_GROUP_DESCRIPTION      (MetadataElement.STUDY_VARIABLE_GROUP,                "description"),
     STUDY_VARIABLE_GROUP_TYPE             (MetadataElement.STUDY_VARIABLE_GROUP,                "type"),
     STUDY_VARIABLE_GROUP_DATATYPE         (MetadataElement.STUDY_VARIABLE_GROUP,                "datatype"),
     STUDY_VARIABLE_GROUP_UNIT             (MetadataElement.STUDY_VARIABLE_GROUP,                "unit"),
+    STUDY_VARIABLE_GROUP_STUDY_VARIABLE_REFS (MetadataElement.STUDY_VARIABLE_GROUP,            "study_variable_refs"),
 
     CV_LABEL                              (MetadataElement.CV,                                  "label"),
     CV_FULL_NAME                          (MetadataElement.CV,                                  "full_name"),

--- a/io/src/main/java/uk/ac/ebi/pride/jmztab2/utils/parser/MTDLineParser.java
+++ b/io/src/main/java/uk/ac/ebi/pride/jmztab2/utils/parser/MTDLineParser.java
@@ -1163,19 +1163,14 @@ public class MTDLineParser extends MZTabLineParser {
                                 LogicalErrorType.DuplicationID, lineNumber,
                                 valueLabel));
                         });
-                    // check that assays exist
+                    // Resolve assays that are already defined; assays defined
+                    // later in the metadata section are recorded by id and
+                    // resolved/validated once the whole section is parsed (see
+                    // StudyVariableValidator).
                     for (IndexedElement e : indexedElementList) {
-                        //assays need to be defined before
-                        if (!context.getAssayMap().
-                            containsKey(e.getId())) {
-                            // can not find assay[id] in metadata.
-                            throw new MZTabException(new MZTabError(
-                                LogicalErrorType.NotDefineInMetadata, lineNumber,
-                                valueLabel));
-                        }
-                        context.addStudyVariableAssay(metadata, id, context.
-                            getAssayMap().
-                            get(e.getId()));
+                        Assay assay = context.getAssayMap().get(e.getId());
+                        context.addStudyVariableAssayRef(metadata, id,
+                            assay != null ? assay : new Assay().id(e.getId()));
                     }
                     break;
                 case STUDY_VARIABLE_AVERAGE_FUNCTION:
@@ -1191,20 +1186,8 @@ public class MTDLineParser extends MZTabLineParser {
                         addStudyVariableDescription(metadata, id, valueLabel);
                     break;
                 case STUDY_VARIABLE_FACTORS:
-                    // removed in version 2.1
-                    //context.addStudyVariableFactors(metadata, id,
-                    //    checkParameter(defineLabel, valueLabel));
-                    //break;
-                case STUDY_VARIABLE_GROUP_REF:
-                    IndexedElement groupRefElement = checkIndexedElement(defineLabel,
-                        valueLabel, MetadataElement.STUDY_VARIABLE_GROUP);
-                    StudyVariableGroup referencedGroup = context.getStudyVariableGroupMap().
-                        get(groupRefElement.getId());
-                    if (referencedGroup == null) {
-                        throw new MZTabException(new MZTabError(
-                            LogicalErrorType.NotDefineInMetadata, lineNumber, valueLabel));
-                    }
-                    context.addStudyVariableGroupRef(metadata, id, referencedGroup);
+                    // study_variable[1-n]-factors was removed in version 2.1 and
+                    // is silently ignored for backwards compatibility.
                     break;
                 default:
                     MZTabError error = new MZTabError(
@@ -1237,6 +1220,29 @@ public class MTDLineParser extends MZTabLineParser {
                 case STUDY_VARIABLE_GROUP_UNIT:
                     context.addStudyVariableGroupUnit(metadata, id,
                         checkParameter(defineLabel, valueLabel));
+                    break;
+                case STUDY_VARIABLE_GROUP_STUDY_VARIABLE_REFS:
+                    List<IndexedElement> svRefs = checkIndexedElementList(
+                        defineLabel, valueLabel, MetadataElement.STUDY_VARIABLE);
+                    // detect duplicates
+                    svRefs.stream().
+                        filter(i ->
+                            Collections.frequency(svRefs, i) > 1).
+                        collect(Collectors.toSet()).
+                        forEach((indexedElement) ->
+                        {
+                            errorList.add(new MZTabError(
+                                LogicalErrorType.DuplicationID, lineNumber,
+                                valueLabel));
+                        });
+                    // The referenced study variables may be defined later in the
+                    // metadata section, so we only record the referenced ids here
+                    // and resolve/validate them once the whole section is parsed
+                    // (see StudyVariableGroupValidator).
+                    for (IndexedElement e : svRefs) {
+                        context.addStudyVariableGroupStudyVariableRef(metadata, id,
+                            new StudyVariable().id(e.getId()));
+                    }
                     break;
                 default:
                     MZTabError error = new MZTabError(

--- a/io/src/main/java/uk/ac/ebi/pride/jmztab2/utils/parser/MZTabParserContext.java
+++ b/io/src/main/java/uk/ac/ebi/pride/jmztab2/utils/parser/MZTabParserContext.java
@@ -1193,6 +1193,35 @@ public class MZTabParserContext {
     }
 
     /**
+     * Add a study_variable[id]-assay_refs entry. The referenced assay may be
+     * defined later in the metadata section, so only its id is recorded here;
+     * resolution and validation happen after the whole metadata section has been
+     * parsed (see StudyVariableValidator).
+     *
+     * @param metadata a {@link org.lifstools.mztab2.model.Metadata} object.
+     * @param id SHOULD be positive integer (study variable id).
+     * @param assayRef the referenced assay (id only).
+     * @return a {@link org.lifstools.mztab2.model.StudyVariable} object.
+     */
+    public StudyVariable addStudyVariableAssayRef(Metadata metadata, Integer id, Assay assayRef) {
+        if (id <= 0) {
+            throw new IllegalArgumentException("study variable id should be greater than 0!");
+        }
+        if (assayRef == null) {
+            throw new NullPointerException("study_variable[n]-assay_refs should not be null.");
+        }
+        StudyVariable studyVariable = studyVariableMap.get(id);
+        if (studyVariable == null) {
+            studyVariable = new StudyVariable();
+            studyVariable.id(id);
+            studyVariableMap.put(id, studyVariable);
+            metadata.addStudyVariableItem(studyVariable);
+        }
+        studyVariable.addAssayRefsItem(assayRef);
+        return studyVariable;
+    }
+
+    /**
      * Add a study_variable[id]-description. A textual description of the study variable.
      *
      * @param metadata a {@link org.lifstools.mztab2.model.Metadata} object.
@@ -1438,35 +1467,33 @@ public class MZTabParserContext {
     }
 
     /**
-     * Add a study_variable[id]-group_ref linking to a StudyVariableGroup.
+     * Add a study_variable_group[id]-study_variable_refs entry. The referenced
+     * study variable may be defined later in the metadata section, so only its
+     * id is recorded here; resolution and validation happen after the whole
+     * metadata section has been parsed.
      *
      * @param metadata a {@link org.lifstools.mztab2.model.Metadata} object.
-     * @param id SHOULD be positive integer (study variable id).
-     * @param group SHOULD NOT be null and SHOULD be defined in metadata first.
-     * @return a {@link org.lifstools.mztab2.model.StudyVariable} object.
+     * @param id SHOULD be positive integer (study variable group id).
+     * @param studyVariableRef the referenced study variable (id only).
+     * @return a {@link org.lifstools.mztab2.model.StudyVariableGroup} object.
      */
-    public StudyVariable addStudyVariableGroupRef(Metadata metadata,
-        Integer id, StudyVariableGroup group) {
+    public StudyVariableGroup addStudyVariableGroupStudyVariableRef(Metadata metadata,
+        Integer id, StudyVariable studyVariableRef) {
         if (id <= 0) {
-            throw new IllegalArgumentException("study_variable id should be greater than 0!");
+            throw new IllegalArgumentException("study_variable_group id should be greater than 0!");
         }
-        if (group == null) {
-            throw new NullPointerException("study_variable[n]-group_ref should not be null.");
+        if (studyVariableRef == null) {
+            throw new NullPointerException("study_variable_group[n]-study_variable_refs should not be null.");
         }
-        if (!studyVariableGroupMap.containsValue(group)) {
-            throw new IllegalArgumentException("study_variable_group should be defined in metadata first");
+        StudyVariableGroup svg = studyVariableGroupMap.get(id);
+        if (svg == null) {
+            svg = new StudyVariableGroup();
+            svg.id(id);
+            studyVariableGroupMap.put(id, svg);
+            metadata.addStudyVariableGroupItem(svg);
         }
-        StudyVariable studyVariable = studyVariableMap.get(id);
-        if (studyVariable == null) {
-            studyVariable = new StudyVariable();
-            studyVariable.id(id);
-            studyVariable.setGroupRef(group);
-            studyVariableMap.put(id, studyVariable);
-            metadata.addStudyVariableItem(studyVariable);
-        } else {
-            studyVariable.setGroupRef(group);
-        }
-        return studyVariable;
+        svg.addStudyVariableRefsItem(studyVariableRef);
+        return svg;
     }
 
     /**

--- a/io/src/test/java/org/lifstools/mztab2/io/StudyVariableGroupParserTest.java
+++ b/io/src/test/java/org/lifstools/mztab2/io/StudyVariableGroupParserTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Leibniz-Institut für Analytische Wissenschaften – ISAS – e.V..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lifstools.mztab2.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.lifstools.mztab2.model.MzTab;
+import org.lifstools.mztab2.model.StudyVariable;
+import org.lifstools.mztab2.model.StudyVariableGroup;
+import static org.lifstools.mztab2.test.utils.ClassPathFile.STUDY_VARIABLE_GROUP;
+import static org.lifstools.mztab2.test.utils.ClassPathFile.STUDY_VARIABLE_GROUP_OFFICIAL_EXAMPLE;
+import org.lifstools.mztab2.test.utils.ExtractClassPathFiles;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.ac.ebi.pride.jmztab2.utils.errors.MZTabErrorType;
+
+/**
+ * End-to-end tests for parsing and validation of the study_variable_group
+ * section using the official mzTab-M 2.1 design, where each group lists its
+ * member study variables via study_variable_group[n]-study_variable_refs.
+ *
+ * @author nilshoffmann
+ */
+public class StudyVariableGroupParserTest {
+
+    @RegisterExtension
+    static final ExtractClassPathFiles EXTRACT_FILES = new ExtractClassPathFiles(
+            STUDY_VARIABLE_GROUP,
+            STUDY_VARIABLE_GROUP_OFFICIAL_EXAMPLE);
+
+    private MzTabFileParser parse(String fileName, MZTabErrorType.Level level) throws IOException {
+        File testFile = new File(EXTRACT_FILES.getBaseDir(), fileName);
+        Assertions.assertTrue(testFile.exists() && testFile.isFile());
+        MzTabFileParser parser = new MzTabFileParser(testFile);
+        parser.parse(System.err, level, 500);
+        return parser;
+    }
+
+    @Test
+    public void testStudyVariableGroupParsesAndValidates() throws Exception {
+        MzTabFileParser parser = parse(STUDY_VARIABLE_GROUP.fileName(),
+            MZTabErrorType.Level.Warn);
+        Assertions.assertEquals(0, parser.getErrorList().size(),
+            parser.getErrorList().toString());
+        MzTab mzTab = parser.getMZTabFile();
+        Assertions.assertNotNull(mzTab);
+
+        Assertions.assertEquals(1, mzTab.getMetadata().getStudyVariableGroup().size());
+        StudyVariableGroup group = mzTab.getMetadata().getStudyVariableGroup().get(0);
+        Assertions.assertEquals("treatment", group.getParameter().getName());
+        Assertions.assertEquals("STATO", group.getType().getCvLabel());
+        Assertions.assertEquals("xsd:string", group.getDatatype());
+
+        // study_variable_refs are resolved to the referenced study variables
+        List<StudyVariable> refs = group.getStudyVariableRefs();
+        Assertions.assertEquals(2, refs.size());
+        Assertions.assertEquals(Integer.valueOf(1), refs.get(0).getId());
+        Assertions.assertEquals("Untreated", refs.get(0).getName());
+        Assertions.assertEquals(Integer.valueOf(2), refs.get(1).getId());
+        Assertions.assertEquals("Treated", refs.get(1).getName());
+    }
+
+    @Test
+    public void testOfficialExampleValidates() throws Exception {
+        // The official example from the HUPO-PSI/mzTab-M examples/2.1 directory.
+        // It uses the top-down study_variable_group[n]-study_variable_refs design
+        // and declares study variables before the assays they reference, exercising
+        // both the study_variable_refs and the deferred assay_refs resolution.
+        MzTabFileParser parser = parse(STUDY_VARIABLE_GROUP_OFFICIAL_EXAMPLE.fileName(),
+            MZTabErrorType.Level.Warn);
+        Assertions.assertEquals(0, parser.getErrorList().size(),
+            parser.getErrorList().toString());
+        MzTab mzTab = parser.getMZTabFile();
+        Assertions.assertNotNull(mzTab);
+
+        Assertions.assertEquals(2, mzTab.getMetadata().getStudyVariableGroup().size());
+        // sex group references study_variable[1] and [2]
+        StudyVariableGroup sex = mzTab.getMetadata().getStudyVariableGroup().get(0);
+        Assertions.assertEquals("sex", sex.getParameter().getName());
+        Assertions.assertEquals(2, sex.getStudyVariableRefs().size());
+        Assertions.assertEquals("Female", sex.getStudyVariableRefs().get(0).getName());
+        // timepoint group references study_variable[3], [4] and [5]
+        StudyVariableGroup timepoint = mzTab.getMetadata().getStudyVariableGroup().get(1);
+        Assertions.assertEquals("timepoint", timepoint.getParameter().getName());
+        Assertions.assertEquals(3, timepoint.getStudyVariableRefs().size());
+    }
+}

--- a/io/src/test/java/org/lifstools/mztab2/io/serialization/StudyVariableGroupSerializerTest.java
+++ b/io/src/test/java/org/lifstools/mztab2/io/serialization/StudyVariableGroupSerializerTest.java
@@ -21,8 +21,10 @@ import org.lifstools.mztab2.io.TestResources;
 import org.lifstools.mztab2.model.Metadata;
 import static org.lifstools.mztab2.model.Metadata.PrefixEnum.MTD;
 import org.lifstools.mztab2.model.Parameter;
+import org.lifstools.mztab2.model.StudyVariable;
 import org.lifstools.mztab2.model.StudyVariableGroup;
 import org.junit.jupiter.api.Test;
+import static uk.ac.ebi.pride.jmztab2.model.MZTabConstants.BAR_S;
 import static uk.ac.ebi.pride.jmztab2.model.MZTabConstants.NEW_LINE;
 import static uk.ac.ebi.pride.jmztab2.model.MZTabConstants.TAB_STRING;
 
@@ -142,6 +144,34 @@ public class StudyVariableGroupSerializerTest extends AbstractSerializerTest {
             + MTD + TAB_STRING + Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[2]-" + StudyVariableGroup.JSON_PROPERTY_TYPE + TAB_STRING + pc.convert(group2.getType())
             + NEW_LINE
             + MTD + TAB_STRING + Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[2]-" + StudyVariableGroup.JSON_PROPERTY_DATATYPE + TAB_STRING + group2.getDatatype()
+            + NEW_LINE,
+            serializeSingle(writer, mtd));
+    }
+
+    @Test
+    public void testSerializeStudyVariableRefs() throws Exception {
+        Metadata mtd = new Metadata();
+        Parameter sexParam = new Parameter().cvLabel("PATO").
+            cvAccession("PATO:0000383").
+            name("sex");
+        StudyVariableGroup group1 = new StudyVariableGroup().
+            id(1).
+            parameter(sexParam).
+            description("Sex of the individual").
+            addStudyVariableRefsItem(new StudyVariable().id(1).name("Female")).
+            addStudyVariableRefsItem(new StudyVariable().id(2).name("Male"));
+        mtd.addStudyVariableGroupItem(group1);
+
+        ObjectWriter writer = metaDataWriter();
+        ParameterConverter pc = new ParameterConverter();
+        assertEqSentry(
+            TestResources.MZTAB_VERSION_HEADER
+            + MTD + TAB_STRING + Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]" + TAB_STRING + pc.convert(sexParam)
+            + NEW_LINE
+            + MTD + TAB_STRING + Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]-" + StudyVariableGroup.JSON_PROPERTY_DESCRIPTION + TAB_STRING + group1.getDescription()
+            + NEW_LINE
+            + MTD + TAB_STRING + Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]-" + StudyVariableGroup.JSON_PROPERTY_STUDY_VARIABLE_REFS + TAB_STRING
+            + Metadata.JSON_PROPERTY_STUDY_VARIABLE + "[1]" + BAR_S + Metadata.JSON_PROPERTY_STUDY_VARIABLE + "[2]"
             + NEW_LINE,
             serializeSingle(writer, mtd));
     }

--- a/io/src/test/java/org/lifstools/mztab2/io/validators/StudyVariableGroupValidatorTest.java
+++ b/io/src/test/java/org/lifstools/mztab2/io/validators/StudyVariableGroupValidatorTest.java
@@ -19,7 +19,6 @@ import org.lifstools.mztab2.model.Metadata;
 import org.lifstools.mztab2.model.Parameter;
 import org.lifstools.mztab2.model.StudyVariable;
 import org.lifstools.mztab2.model.StudyVariableGroup;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -38,6 +37,10 @@ public class StudyVariableGroupValidatorTest {
     private static final Parameter STATO_CATEGORICAL = new Parameter().
         cvLabel("STATO").cvAccession("STATO:0000252").name("categorical variable");
 
+    private static StudyVariable studyVariable(int id) {
+        return new StudyVariable().id(id).name("sv" + id).description("study variable " + id);
+    }
+
     /** No groups declared → validator is a no-op, no errors expected. */
     @Test
     public void testEmptyGroupMapProducesNoErrors() {
@@ -49,24 +52,23 @@ public class StudyVariableGroupValidatorTest {
         assertTrue(result.isEmpty());
     }
 
-    /** Valid group with all mandatory fields, referenced by a study variable → no errors. */
+    /** Valid group with all mandatory fields referencing a defined study variable → no errors. */
     @Test
-    public void testValidGroupReferencedByStudyVariable() {
+    public void testValidGroupReferencingStudyVariable() {
         Metadata metadata = new Metadata();
         MZTabParserContext parserContext = new MZTabParserContext();
 
+        StudyVariable sv1 = studyVariable(1);
+        parserContext.addStudyVariable(metadata, sv1);
         StudyVariableGroup group = new StudyVariableGroup().id(1).
             parameter(PATO_SEX).
-            description("Sex of the individual");
+            description("Sex of the individual").
+            addStudyVariableRefsItem(sv1);
         parserContext.addStudyVariableGroup(metadata, group);
-
-        StudyVariable sv = new StudyVariable().id(1).name("Female").
-            description("Female samples").groupRef(group);
-        parserContext.addStudyVariable(metadata, sv);
 
         StudyVariableGroupValidator instance = new StudyVariableGroupValidator();
         List<MZTabError> result = instance.validateRefine(metadata, parserContext);
-        assertTrue(result.isEmpty());
+        assertTrue(result.isEmpty(), result.toString());
     }
 
     /** Valid group with all optional fields populated → no errors. */
@@ -75,21 +77,20 @@ public class StudyVariableGroupValidatorTest {
         Metadata metadata = new Metadata();
         MZTabParserContext parserContext = new MZTabParserContext();
 
+        StudyVariable sv1 = studyVariable(1);
+        parserContext.addStudyVariable(metadata, sv1);
         StudyVariableGroup group = new StudyVariableGroup().id(1).
             parameter(PATO_SEX).
             description("Sex of the individual").
             type(STATO_CATEGORICAL).
             datatype("xsd:string").
-            unit(new Parameter().cvLabel("UO").cvAccession("UO:0000189").name("count unit"));
+            unit(new Parameter().cvLabel("UO").cvAccession("UO:0000189").name("count unit")).
+            addStudyVariableRefsItem(sv1);
         parserContext.addStudyVariableGroup(metadata, group);
-
-        StudyVariable sv = new StudyVariable().id(1).name("Female").
-            description("Female samples").groupRef(group);
-        parserContext.addStudyVariable(metadata, sv);
 
         StudyVariableGroupValidator instance = new StudyVariableGroupValidator();
         List<MZTabError> result = instance.validateRefine(metadata, parserContext);
-        assertTrue(result.isEmpty());
+        assertTrue(result.isEmpty(), result.toString());
     }
 
     /** Group with null parameter → error for missing mandatory field. */
@@ -98,23 +99,20 @@ public class StudyVariableGroupValidatorTest {
         Metadata metadata = new Metadata();
         MZTabParserContext parserContext = new MZTabParserContext();
 
+        StudyVariable sv1 = studyVariable(1);
+        parserContext.addStudyVariable(metadata, sv1);
         StudyVariableGroup group = new StudyVariableGroup().id(1).
-            description("Sex of the individual");
+            description("Sex of the individual").
+            addStudyVariableRefsItem(sv1);
         parserContext.addStudyVariableGroup(metadata, group);
 
-        StudyVariable sv = new StudyVariable().id(1).name("Female").
-            description("Female samples").groupRef(group);
-        parserContext.addStudyVariable(metadata, sv);
-
         StudyVariableGroupValidator instance = new StudyVariableGroupValidator();
-        List<MZTabError> expResult = Arrays.asList(
-            new MZTabError(LogicalErrorType.NotDefineInMetadata, -1,
-                Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]"
-                + "\t<" + StudyVariableGroup.JSON_PROPERTY_PARAMETER + ">")
-        );
         List<MZTabError> result = instance.validateRefine(metadata, parserContext);
-        assertEquals(expResult.size(), result.size());
-        assertEquals(expResult.get(0).toString(), result.get(0).toString());
+        assertEquals(1, result.size(), result.toString());
+        assertEquals(new MZTabError(LogicalErrorType.NotDefineInMetadata, -1,
+            Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]"
+            + "\t<" + StudyVariableGroup.JSON_PROPERTY_PARAMETER + ">").toString(),
+            result.get(0).toString());
     }
 
     /** Group with null description → error for missing mandatory field. */
@@ -123,23 +121,20 @@ public class StudyVariableGroupValidatorTest {
         Metadata metadata = new Metadata();
         MZTabParserContext parserContext = new MZTabParserContext();
 
+        StudyVariable sv1 = studyVariable(1);
+        parserContext.addStudyVariable(metadata, sv1);
         StudyVariableGroup group = new StudyVariableGroup().id(1).
-            parameter(PATO_SEX);
+            parameter(PATO_SEX).
+            addStudyVariableRefsItem(sv1);
         parserContext.addStudyVariableGroup(metadata, group);
 
-        StudyVariable sv = new StudyVariable().id(1).name("Female").
-            description("Female samples").groupRef(group);
-        parserContext.addStudyVariable(metadata, sv);
-
         StudyVariableGroupValidator instance = new StudyVariableGroupValidator();
-        List<MZTabError> expResult = Arrays.asList(
-            new MZTabError(LogicalErrorType.NotDefineInMetadata, -1,
-                Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]-"
-                + StudyVariableGroup.JSON_PROPERTY_DESCRIPTION)
-        );
         List<MZTabError> result = instance.validateRefine(metadata, parserContext);
-        assertEquals(expResult.size(), result.size());
-        assertEquals(expResult.get(0).toString(), result.get(0).toString());
+        assertEquals(1, result.size(), result.toString());
+        assertEquals(new MZTabError(LogicalErrorType.NotDefineInMetadata, -1,
+            Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]-"
+            + StudyVariableGroup.JSON_PROPERTY_DESCRIPTION).toString(),
+            result.get(0).toString());
     }
 
     /** Group type with a non-STATO cv label → error. */
@@ -148,28 +143,25 @@ public class StudyVariableGroupValidatorTest {
         Metadata metadata = new Metadata();
         MZTabParserContext parserContext = new MZTabParserContext();
 
+        StudyVariable sv1 = studyVariable(1);
+        parserContext.addStudyVariable(metadata, sv1);
         Parameter invalidType = new Parameter().cvLabel("MS").
             cvAccession("MS:1000001").name("some ms term");
         StudyVariableGroup group = new StudyVariableGroup().id(1).
             parameter(PATO_SEX).
             description("Sex of the individual").
-            type(invalidType);
+            type(invalidType).
+            addStudyVariableRefsItem(sv1);
         parserContext.addStudyVariableGroup(metadata, group);
 
-        StudyVariable sv = new StudyVariable().id(1).name("Female").
-            description("Female samples").groupRef(group);
-        parserContext.addStudyVariable(metadata, sv);
-
         StudyVariableGroupValidator instance = new StudyVariableGroupValidator();
-        List<MZTabError> expResult = Arrays.asList(
-            new MZTabError(LogicalErrorType.NotDefineInMetadata, -1,
-                Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]-"
-                + StudyVariableGroup.JSON_PROPERTY_TYPE
-                + " (MUST be a STATO ontology term, e.g. [STATO, STATO:0000252, categorical variable, ])")
-        );
         List<MZTabError> result = instance.validateRefine(metadata, parserContext);
-        assertEquals(expResult.size(), result.size());
-        assertEquals(expResult.get(0).toString(), result.get(0).toString());
+        assertEquals(1, result.size(), result.toString());
+        assertEquals(new MZTabError(LogicalErrorType.NotDefineInMetadata, -1,
+            Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]-"
+            + StudyVariableGroup.JSON_PROPERTY_TYPE
+            + " (MUST be a STATO ontology term, e.g. [STATO, STATO:0000252, categorical variable, ])").toString(),
+            result.get(0).toString());
     }
 
     /** Group with an unsupported xsd datatype value → error. */
@@ -178,31 +170,28 @@ public class StudyVariableGroupValidatorTest {
         Metadata metadata = new Metadata();
         MZTabParserContext parserContext = new MZTabParserContext();
 
+        StudyVariable sv1 = studyVariable(1);
+        parserContext.addStudyVariable(metadata, sv1);
         StudyVariableGroup group = new StudyVariableGroup().id(1).
             parameter(PATO_SEX).
             description("Sex of the individual").
-            datatype("xsd:unsupported");
+            datatype("xsd:unsupported").
+            addStudyVariableRefsItem(sv1);
         parserContext.addStudyVariableGroup(metadata, group);
 
-        StudyVariable sv = new StudyVariable().id(1).name("Female").
-            description("Female samples").groupRef(group);
-        parserContext.addStudyVariable(metadata, sv);
-
         StudyVariableGroupValidator instance = new StudyVariableGroupValidator();
-        List<MZTabError> expResult = Arrays.asList(
-            new MZTabError(LogicalErrorType.NotDefineInMetadata, -1,
-                Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]-"
-                + StudyVariableGroup.JSON_PROPERTY_DATATYPE
-                + " (MUST be one of: xsd:string, xsd:integer, xsd:decimal, xsd:boolean, xsd:date, xsd:time, xsd:dateTime, xsd:anyURI)")
-        );
         List<MZTabError> result = instance.validateRefine(metadata, parserContext);
-        assertEquals(expResult.size(), result.size());
-        assertEquals(expResult.get(0).toString(), result.get(0).toString());
+        assertEquals(1, result.size(), result.toString());
+        assertEquals(new MZTabError(LogicalErrorType.NotDefineInMetadata, -1,
+            Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]-"
+            + StudyVariableGroup.JSON_PROPERTY_DATATYPE
+            + " (MUST be one of: xsd:string, xsd:integer, xsd:decimal, xsd:boolean, xsd:date, xsd:time, xsd:dateTime, xsd:anyURI)").toString(),
+            result.get(0).toString());
     }
 
-    /** Group not referenced by any study variable → StudyVariableNotDefined error. */
+    /** Group without any study_variable_refs → error. */
     @Test
-    public void testUnreferencedGroupProducesError() {
+    public void testGroupWithoutStudyVariableRefsProducesError() {
         Metadata metadata = new Metadata();
         MZTabParserContext parserContext = new MZTabParserContext();
 
@@ -211,16 +200,54 @@ public class StudyVariableGroupValidatorTest {
             description("Sex of the individual");
         parserContext.addStudyVariableGroup(metadata, group);
 
-        // No study variable with groupRef → group is unreferenced
         StudyVariableGroupValidator instance = new StudyVariableGroupValidator();
-        List<MZTabError> expResult = Arrays.asList(
-            new MZTabError(LogicalErrorType.StudyVariableNotDefined, -1,
-                Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]"
-                + " is not referenced by any study_variable[n]-group_ref")
-        );
         List<MZTabError> result = instance.validateRefine(metadata, parserContext);
-        assertEquals(expResult.size(), result.size());
-        assertEquals(expResult.get(0).toString(), result.get(0).toString());
+        assertEquals(1, result.size(), result.toString());
+        assertEquals(new MZTabError(LogicalErrorType.NotDefineInMetadata, -1,
+            Metadata.JSON_PROPERTY_STUDY_VARIABLE_GROUP + "[1]-"
+            + StudyVariableGroup.JSON_PROPERTY_STUDY_VARIABLE_REFS).toString(),
+            result.get(0).toString());
+    }
+
+    /** A study_variable_refs entry pointing to an undefined study variable → error. */
+    @Test
+    public void testUnknownStudyVariableRefProducesError() {
+        Metadata metadata = new Metadata();
+        MZTabParserContext parserContext = new MZTabParserContext();
+
+        StudyVariableGroup group = new StudyVariableGroup().id(1).
+            parameter(PATO_SEX).
+            description("Sex of the individual").
+            addStudyVariableRefsItem(new StudyVariable().id(99));
+        parserContext.addStudyVariableGroup(metadata, group);
+
+        StudyVariableGroupValidator instance = new StudyVariableGroupValidator();
+        List<MZTabError> result = instance.validateRefine(metadata, parserContext);
+        assertTrue(result.stream().anyMatch(e -> e.getMessage().contains("study_variable[99]")),
+            result.toString());
+    }
+
+    /** A study variable not referenced by any group → error once groups are defined. */
+    @Test
+    public void testUnreferencedStudyVariableProducesError() {
+        Metadata metadata = new Metadata();
+        MZTabParserContext parserContext = new MZTabParserContext();
+
+        StudyVariable sv1 = studyVariable(1);
+        StudyVariable sv2 = studyVariable(2);
+        parserContext.addStudyVariable(metadata, sv1);
+        parserContext.addStudyVariable(metadata, sv2);
+        StudyVariableGroup group = new StudyVariableGroup().id(1).
+            parameter(PATO_SEX).
+            description("Sex of the individual").
+            addStudyVariableRefsItem(sv1);
+        parserContext.addStudyVariableGroup(metadata, group);
+
+        StudyVariableGroupValidator instance = new StudyVariableGroupValidator();
+        List<MZTabError> result = instance.validateRefine(metadata, parserContext);
+        assertEquals(1, result.size(), result.toString());
+        assertEquals(LogicalErrorType.StudyVariableNotDefined, result.get(0).getType());
+        assertTrue(result.get(0).getMessage().contains("study_variable[2]"), result.toString());
     }
 
     /** All valid xsd datatypes are accepted without error. */
@@ -234,19 +261,18 @@ public class StudyVariableGroupValidatorTest {
             Metadata metadata = new Metadata();
             MZTabParserContext parserContext = new MZTabParserContext();
 
+            StudyVariable sv1 = studyVariable(1);
+            parserContext.addStudyVariable(metadata, sv1);
             StudyVariableGroup group = new StudyVariableGroup().id(1).
                 parameter(PATO_SEX).
                 description("Sex of the individual").
-                datatype(datatype);
+                datatype(datatype).
+                addStudyVariableRefsItem(sv1);
             parserContext.addStudyVariableGroup(metadata, group);
-
-            StudyVariable sv = new StudyVariable().id(1).name("Female").
-                description("Female samples").groupRef(group);
-            parserContext.addStudyVariable(metadata, sv);
 
             StudyVariableGroupValidator instance = new StudyVariableGroupValidator();
             List<MZTabError> result = instance.validateRefine(metadata, parserContext);
-            assertTrue(result.isEmpty(), "Expected no errors for datatype: " + datatype);
+            assertTrue(result.isEmpty(), "Expected no errors for datatype: " + datatype + " " + result);
         }
     }
 }

--- a/test-utils/src/main/java/org/lifstools/mztab2/test/utils/ClassPathFile.java
+++ b/test-utils/src/main/java/org/lifstools/mztab2/test/utils/ClassPathFile.java
@@ -40,7 +40,9 @@ public enum ClassPathFile {
     LIPIDOMICS_EXAMPLE_WRONG_MSSCAN_REF("/metabolomics/", "lipidomics-example-wrong-msscan-ref.mzTab"),
     MINIMAL_EXAMPLE("/metabolomics/", "minimal-m-2.0.mztab"),
     XCMS_EXAMPLE("/metabolomics/", "xcms-test-export.mztab"),
-    XCMS_NO_SML_EXAMPLE("/metabolomics/", "xcms-test-export-nosml.mztab");
+    XCMS_NO_SML_EXAMPLE("/metabolomics/", "xcms-test-export-nosml.mztab"),
+    STUDY_VARIABLE_GROUP("/metabolomics/", "study-variable-group.mztab"),
+    STUDY_VARIABLE_GROUP_OFFICIAL_EXAMPLE("/metabolomics/", "example_study_variable_group.mztab");
 
     private final String resourcePathPrefix;
     private final String fileName;

--- a/test-utils/src/main/resources/metabolomics/example_study_variable_group.mztab
+++ b/test-utils/src/main/resources/metabolomics/example_study_variable_group.mztab
@@ -1,0 +1,117 @@
+COM	Example demonstrating the study_variable_group design (mzTab-M 2.1)
+COM
+COM	Model: each study_variable_group is one experimental factor (a column of the
+COM	wide design matrix). Each study_variable is one level of exactly one factor and
+COM	references the assays that carry that level. The link is top-down: every group
+COM	lists its member study variables via study_variable_group[1-n]-study_variable_refs.
+COM
+COM	Design: sex (2 levels) x timepoint (3 levels), one assay per cell (assay[1-6]).
+COM	  assay[1] Female,0day  assay[2] Female,1day  assay[3] Female,2day
+COM	  assay[4] Male,0day    assay[5] Male,1day    assay[6] Male,2day
+
+MTD	mzTab-version	2.1.0-M
+MTD	mzTab-ID	EXAMPLE_SV_GROUP_001
+MTD	title	Multi-factorial design with sex and timepoint factors
+MTD	description	Example dataset demonstrating study_variable_group for multi-factorial designs
+MTD	quantification_method	[MS, MS:1001834, LC-MS label-free quantitation analysis, ]
+MTD	software[1]	[MS, MS:1002879, Progenesis QI, 3.0]
+
+COM	MS runs (one per assay)
+MTD	ms_run[1]-location	file:///data/run1.mzML
+MTD	ms_run[1]-format	[MS, MS:1000584, mzML file, ]
+MTD	ms_run[1]-id_format	[MS, MS:1000768, Thermo nativeID format, ]
+MTD	ms_run[1]-scan_polarity[1]	[MS, MS:1000129, negative scan, ]
+MTD	ms_run[2]-location	file:///data/run2.mzML
+MTD	ms_run[2]-format	[MS, MS:1000584, mzML file, ]
+MTD	ms_run[2]-id_format	[MS, MS:1000768, Thermo nativeID format, ]
+MTD	ms_run[2]-scan_polarity[1]	[MS, MS:1000129, negative scan, ]
+MTD	ms_run[3]-location	file:///data/run3.mzML
+MTD	ms_run[3]-format	[MS, MS:1000584, mzML file, ]
+MTD	ms_run[3]-id_format	[MS, MS:1000768, Thermo nativeID format, ]
+MTD	ms_run[3]-scan_polarity[1]	[MS, MS:1000129, negative scan, ]
+MTD	ms_run[4]-location	file:///data/run4.mzML
+MTD	ms_run[4]-format	[MS, MS:1000584, mzML file, ]
+MTD	ms_run[4]-id_format	[MS, MS:1000768, Thermo nativeID format, ]
+MTD	ms_run[4]-scan_polarity[1]	[MS, MS:1000129, negative scan, ]
+MTD	ms_run[5]-location	file:///data/run5.mzML
+MTD	ms_run[5]-format	[MS, MS:1000584, mzML file, ]
+MTD	ms_run[5]-id_format	[MS, MS:1000768, Thermo nativeID format, ]
+MTD	ms_run[5]-scan_polarity[1]	[MS, MS:1000129, negative scan, ]
+MTD	ms_run[6]-location	file:///data/run6.mzML
+MTD	ms_run[6]-format	[MS, MS:1000584, mzML file, ]
+MTD	ms_run[6]-id_format	[MS, MS:1000768, Thermo nativeID format, ]
+MTD	ms_run[6]-scan_polarity[1]	[MS, MS:1000129, negative scan, ]
+
+COM	Assays (one per design cell)
+MTD	assay[1]	Female_0day
+MTD	assay[1]-ms_run_ref	ms_run[1]
+MTD	assay[2]	Female_1day
+MTD	assay[2]-ms_run_ref	ms_run[2]
+MTD	assay[3]	Female_2day
+MTD	assay[3]-ms_run_ref	ms_run[3]
+MTD	assay[4]	Male_0day
+MTD	assay[4]-ms_run_ref	ms_run[4]
+MTD	assay[5]	Male_1day
+MTD	assay[5]-ms_run_ref	ms_run[5]
+MTD	assay[6]	Male_2day
+MTD	assay[6]-ms_run_ref	ms_run[6]
+
+COM	Study Variable Groups (the factors)
+COM	sex - categorical (nominal), string values
+MTD	study_variable_group[1]	[,,sex,]
+MTD	study_variable_group[1]-description	Sex of the individual
+MTD	study_variable_group[1]-type	[STATO, STATO:0000252, categorical variable, ]
+MTD	study_variable_group[1]-datatype	xsd:string
+MTD	study_variable_group[1]-study_variable_refs	study_variable[1]| study_variable[2]
+COM	timepoint - ordinal, integer values with a unit
+MTD	study_variable_group[2]	[,,timepoint,]
+MTD	study_variable_group[2]-description	Time after treatment
+MTD	study_variable_group[2]-type	[STATO, STATO:0000228, ordinal variable, ]
+MTD	study_variable_group[2]-datatype	xsd:integer
+MTD	study_variable_group[2]-unit	[UO, UO:0000033, day, ]
+MTD	study_variable_group[2]-study_variable_refs	study_variable[3]| study_variable[4]| study_variable[5]
+
+COM	Study Variables (the levels of each factor)
+COM	sex levels
+MTD	study_variable[1]	Female
+MTD	study_variable[1]-description	Female individuals
+MTD	study_variable[1]-assay_refs	assay[1]| assay[2]| assay[3]
+MTD	study_variable[2]	Male
+MTD	study_variable[2]-description	Male individuals
+MTD	study_variable[2]-assay_refs	assay[4]| assay[5]| assay[6]
+COM	timepoint levels
+MTD	study_variable[3]	0
+MTD	study_variable[3]-description	Control timepoint (0 days)
+MTD	study_variable[3]-assay_refs	assay[1]| assay[4]
+MTD	study_variable[4]	1
+MTD	study_variable[4]-description	1 day post-treatment
+MTD	study_variable[4]-assay_refs	assay[2]| assay[5]
+MTD	study_variable[5]	2
+MTD	study_variable[5]-description	2 days post-treatment
+MTD	study_variable[5]-assay_refs	assay[3]| assay[6]
+
+COM	Controlled vocabularies
+MTD	cv[1]-label	MS
+MTD	cv[1]-full_name	PSI-MS controlled vocabulary
+MTD	cv[1]-version	4.1.11
+MTD	cv[1]-uri	https://purl.obolibrary.org/obo/ms.obo
+MTD	cv[2]-label	UO
+MTD	cv[2]-full_name	Unit Ontology
+MTD	cv[2]-version	2021-11-08
+MTD	cv[2]-uri	https://purl.obolibrary.org/obo/uo.obo
+MTD	cv[3]-label	STATO
+MTD	cv[3]-full_name	Statistics Ontology
+MTD	cv[3]-version	2018-06-15
+MTD	cv[3]-uri	https://purl.obolibrary.org/obo/stato.owl
+
+MTD	small_molecule-quantification_unit	[MS, MS:1002887, Progenesis QI normalised abundance, ]
+MTD	small_molecule_feature-quantification_unit	[MS, MS:1002887, Progenesis QI normalised abundance, ]
+MTD	small_molecule-identification_reliability	[MS, MS:1002896, compound identification confidence level, ]
+MTD	database[1]	[MIRIAM, MIR:00100079, HMDB, ]
+MTD	database[1]-prefix	hmdb
+MTD	database[1]-version	3.6
+MTD	database[1]-uri	http://www.hmdb.ca/
+
+COM	Small Molecule section (minimal example)
+SMH	SML_ID	SMF_ID_REFS	database_identifier	chemical_formula	smiles	inchi	chemical_name	uri	theoretical_neutral_mass	adduct_ions	reliability	best_id_confidence_measure	best_id_confidence_value	abundance_assay[1]	abundance_assay[2]	abundance_assay[3]	abundance_assay[4]	abundance_assay[5]	abundance_assay[6]	abundance_study_variable[1]	abundance_study_variable[2]	abundance_study_variable[3]	abundance_study_variable[4]	abundance_study_variable[5]	abundance_variation_study_variable[1]	abundance_variation_study_variable[2]	abundance_variation_study_variable[3]	abundance_variation_study_variable[4]	abundance_variation_study_variable[5]
+SML	1	null	hmdb:HMDB0000043	C6H12O6	C([C@@H]1[C@H]([C@@H]([C@H](C(=O)O1)O)O)O)O	InChI=1S/C6H12O6/c7-1-2-3(8)4(9)5(10)6(11)12-2/h2-11H,1H2	D-Gluconic acid	http://www.hmdb.ca/metabolites/HMDB0000043	196.0423	[M-H]1-	2	[MS, MS:1002888, SpectraScore, ]	0.85	1.51	1.62	1.44	2.13	2.05	2.21	1.52	2.13	1.82	1.84	1.83	0.11	0.14	0.12	0.13	0.10

--- a/test-utils/src/main/resources/metabolomics/study-variable-group.mztab
+++ b/test-utils/src/main/resources/metabolomics/study-variable-group.mztab
@@ -1,0 +1,97 @@
+COM	Meta data section																		
+MTD	mzTab-version	2.0.0-M																	
+MTD	mzTab-ID	mzTab-GCxGC-MS																	
+MTD	description	Minimal sample file for GCxGC-MS quantification of small molecules between two experiments																	
+MTD	instrument[1]-name	[MS, MS:1001945, Pegasus 4D, ]																	
+MTD	instrument[1]-source	[MS, MS:1000389, electron Ionization, ]																	
+MTD	instrument[1]-analyzer[1]	[MS, MS:1000084, time-of-flight, ]																	
+MTD	instrument[1]-detector	[MS, MS:1000114, microchannel plate detector, ]																	
+MTD	software[1]	[MS, MS:1001799, ChromaTOF software, 3.21]
+MTD	software[1]-setting[1]	baseline=0.2
+MTD	software[1]-setting[2]	dbMatchTreshold=900
+MTD	sample[1]-species[1]	[NCBITaxon, NCBITaxon:9606, Homo sapiens, ]																	
+MTD	sample[1]-cell_type[1]	[CL, CL:0000233, platelet, ]																	
+MTD	sample[1]-description	Unstimulated human blood platelets																	
+MTD	sample[2]-species[1]	[NCBITaxon, NCBITaxon:9606, Homo sapiens, ]																	
+MTD	sample[2]-cell_type[1]	[CL, CL:0000233, platelet, ]																	
+MTD	sample[2]-description	Unstimulated human blood platelets																	
+MTD	ms_run[1]-location	file://c:/data/control.mzML																	
+MTD	ms_run[1]-format	[MS, MS:1000584, mzML file, ]																	
+MTD	ms_run[1]-id_format	[MS, MS:1000776, scan number only nativeID format, ]
+MTD	ms_run[1]-scan_polarity[1]	[MS, MS:1000130, positive scan, ]																	
+MTD	ms_run[2]-location	file://c:/data/treatment.mzML																	
+MTD	ms_run[2]-format	[MS, MS:1000584, mzML file, ]																	
+MTD	ms_run[2]-id_format	[MS, MS:1000776, scan number only nativeID format, ]
+MTD	ms_run[2]-scan_polarity[1]	[MS, MS:1000130, positive scan, ]																	
+MTD	assay[1]-sample_ref	sample[1]																	
+MTD	assay[1]-ms_run_ref	ms_run[1]																	
+MTD	assay[2]-sample_ref	sample[2]																	
+MTD	assay[2]-ms_run_ref	ms_run[2]																	
+MTD	study_variable_group[1]	[,,treatment,]
+MTD	study_variable_group[1]-description	Drug treatment status
+MTD	study_variable_group[1]-type	[STATO, STATO:0000252, categorical variable, ]
+MTD	study_variable_group[1]-datatype	xsd:string
+MTD	study_variable_group[1]-study_variable_refs	study_variable[1]| study_variable[2]
+MTD	study_variable[1]	Untreated																	
+MTD	study_variable[1]-assay_refs	assay[1]																	
+MTD	study_variable[1]-description	drug response control																	
+MTD	study_variable[1]-average_function	[MS, MS:1002962, mean, ]																	
+MTD	study_variable[1]-variation_function	[MS, MS:1002885, standard error, ]																	
+MTD	study_variable[2]	Treated																	
+MTD	study_variable[2]-assay_refs	assay[2]																	
+MTD	study_variable[2]-description	drug response treatment																	
+MTD	study_variable[2]-average_function	[MS, MS:1002962, mean, ]																	
+MTD	study_variable[2]-variation_function	[MS, MS:1002885, standard error, ]																	
+MTD	cv[1]-label	MS																	
+MTD	cv[1]-full_name	PSI-MS controlled vocabulary																	
+MTD	cv[1]-version	20-06-2018																	
+MTD	cv[1]-uri	https://www.ebi.ac.uk/ols/ontologies/ms																	
+MTD	cv[2]-label	NCBITaxon																	
+MTD	cv[2]-full_name	An ontology representation of the NCBI organismal taxonomy Ontology																	
+MTD	cv[2]-version	2018-03-02																	
+MTD	cv[2]-uri	https://www.ebi.ac.uk/ols/ontologies/ncbitaxon																	
+MTD	cv[3]-label	CL																	
+MTD	cv[3]-full_name	The Cell Ontology is a structured controlled vocabulary for cell types in animals.																	
+MTD	cv[3]-version	2017-12-11																	
+MTD	cv[3]-uri	https://www.ebi.ac.uk/ols/ontologies/cl																	
+MTD	cv[4]-label	PRIDE																	
+MTD	cv[4]-full_name	PRIDE PRoteomics IDEntifications (PRIDE) database controlled vocabulary																	
+MTD	cv[4]-version	14-06-2018																	
+MTD	cv[4]-uri	https://www.ebi.ac.uk/ols/ontologies/pride																	
+MTD	cv[5]-label	CHEBI																	
+MTD	cv[5]-full_name	Chemical Entities of Biological Interest
+MTD	cv[5]-version	08-02-2019																	
+MTD	cv[5]-uri	https://www.ebi.ac.uk/ols/ontologies/chebi
+MTD	database[1]	[, ,Golm Metabolite Database, ]																	
+MTD	database[1]-prefix	GMD																	
+MTD	database[1]-version	2.3																	
+MTD	database[1]-uri	http://gmd.mpimp-golm.mpg.de/																	
+MTD	database[2]	[, , no database, null]																	
+MTD	database[2]-prefix	null																	
+MTD	database[2]-uri	null																	
+MTD	database[2]-version	Unknown																	
+MTD	derivatization_agent[1]	[,,Methoxylamine hydrochloride,]																	
+MTD	derivatization_agent[2]	[CHEBI, CHEBI:85064, N-methyl-N-(trimethylsilyl)trifluoroacetamide,]																	
+MTD	small_molecule-identification_reliability	[MS, MS:1002896, compound identification confidence level, ]																	
+MTD	id_confidence_measure[1]	[MS, MS:1002890, fragmentation score, ]																	
+MTD	small_molecule-quantification_unit	[PRIDE, PRIDE:0000330, Arbitrary quantification unit, ]																	
+MTD	small_molecule_feature-quantification_unit	[PRIDE, PRIDE:0000330, Arbitrary quantification unit, ]																	
+MTD	quantification_method	[,,baseline-corrected intensity quantification,]																	
+MTD	custom[1]	[MS, MS:1000901, retention time normalization standard, n-alkanes C10–C36]																	
+																			
+COM	Small molecule summary rows (similar to Protein section). 																		
+COM	Evidences (e.g. multiple modifications, adducts incl. charge variants are summarized). 																		
+COM	For most use cases this summary lines might be sufficient.																		
+SMH	SML_ID	SMF_ID_REFS	database_identifier	chemical_formula	smiles	inchi	chemical_name	uri	theoretical_neutral_mass	adduct_ions	reliability	best_id_confidence_measure	best_id_confidence_value	abundance_assay[1]	abundance_study_variable[1]	abundance_variation_study_variable[1]	abundance_assay[2]	abundance_study_variable[2]	abundance_variation_study_variable[2]
+SML	1	1 | 2	GMD:cd7993ea-ad14-452a-a907-33376cc98790	C18H36O2	CCCCCCCCCCCCCCCCCC(O)=O	InChI=1S/C18H36O2/c1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18(19)20/h2-17H2,1H3,(H,19,20)	Octadecanoic acid	http://identifiers.org/gmd/cd7993ea-ad14-452a-a907-33376cc98790	284.478	[M+H]1+	2	[MS, MS:1002890, fragmentation score, ]	978	805.16	805.16	0	589.9	589.9	0
+																			
+COM	Small molecule feature rows (only reported in Complete Quantification files and if feature information like e.g. mass traces are important)																		
+SFH	SMF_ID	SME_ID_REFS	SME_ID_REF_ambiguity_code	adduct_ion	isotopomer	exp_mass_to_charge	charge	retention_time_in_seconds	retention_time_in_seconds_start	retention_time_in_seconds_end	abundance_assay[1]	abundance_assay[2]	opt_global_retention_time_nd	opt_global_retention_time_nd_window_start	opt_global_retention_time_nd_window_end				
+SMF	1	1	null	[M+H]1+	null	285.484	1	1564.47	1559.45	1564.48	805.16	805.16	1562 | 2.47 	1557 | 2.45 	1562 | 2.48				
+SMF	2	2	null	[M+H]1+	null	285.484	1	1564.48	1554.45	1569.47	589.9	589.9	1562 | 2.48	1552 | 2.45	1567| 2.47				
+																			
+COM	Small molecule evidence rows for parent ions. Analog to PSM. 																		
+COM	Primary use case: report single hits from spectral library or accurate mass searches without quantification.																		
+SEH	SME_ID	evidence_input_id	database_identifier	chemical_formula	smiles	inchi	chemical_name	uri	derivatized_form	adduct_ion	exp_mass_to_charge	charge	theoretical_mass_to_charge	spectra_ref	identification_method	ms_level	id_confidence_measure[1]	rank	
+SME	1	ms_run[1]:scan=8	GMD:f634c736-39e8-4323-8155-fa3cc26ac9e3	C18H36O2	CCCCCCCCCCCCCCCCCC(O)=O	InChI=1S/C18H36O2/c1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18(19)20/h2-17H2,1H3,(H,19,20)	Octadecanoic acid (1TMS)	http://identifiers.org/gmd.analyte/f634c736-39e8-4323-8155-fa3cc26ac9e3	[CHEBI, CHEBI:51088, trimethylsilyl group, 1]	[M+H]+	356.6588	1	356.659	ms_run[1]:scan=8	[,, ChromaTOF database search,]	[MS, MS:1000511, ms level, 1]	957	1	
+SME	2	ms_run[2]:scan=23	GMD:f634c736-39e8-4323-8155-fa3cc26ac9e3	C18H36O2	CCCCCCCCCCCCCCCCCC(O)=O	InChI=1S/C18H36O2/c1-2-3-4-5-6-7-8-9-10-11-12-13-14-15-16-17-18(19)20/h2-17H2,1H3,(H,19,20)	Octadecanoic acid (1TMS)	http://identifiers.org/gmd.analyte/f634c736-39e8-4323-8155-fa3cc26ac9e3	[CHEBI, CHEBI:51088, trimethylsilyl group, 1]	[M+H]+	356.6589	1	356.659	ms_run[2]:scan=23	[,, ChromaTOF database search,]	[MS, MS:1000511, ms level, 1]	972	1	


### PR DESCRIPTION
## Support the mzTab-M 2.1 study_variable_group design

Reworks study variable group support to match the recent update of mzTab-M 2.1
specification, where a group declares its members top-down via
`study_variable_group[n]-study_variable_refs` (a bar-separated list of
`study_variable[i]` references). The previous `study_variable[n]-group_ref`
link (the inverse direction) is removed.

### Design

`study_variable_group[n]-study_variable_refs study_variable[1]| study_variable[2]`
is structurally identical to the existing `study_variable[n]-assay_refs`, so it
is implemented the same way. Because groups are declared *before* the study
variables they reference (a forward reference), the parser records the
referenced ids and defers resolution/validation until the whole metadata
section has been parsed the same approach already used for the SML→SMF→SME
cross-references.

The same forward-reference handling is now applied to `study_variable[n]-assay_refs`
as well, so that files declaring study variables before the assays they
reference (as the reference example does) parse correctly instead of aborting.
Assays that are already defined still resolve immediately (unchanged behaviour);
only forward references are deferred.

Are you ok with that @nilshoffmann ? i did not want to enforce the order. 

### Changes

- **Spec** (`mzTab_m_openapi.yml`): add `study_variable_refs` to
  `StudyVariableGroup`; remove `group_ref` from `StudyVariable`; update examples.
- **Model**: `StudyVariableGroup.studyVariableRefs` added; `StudyVariable.groupRef`
  removed.
- **Parser** (`MetadataProperty`, `MTDLineParser`, `MZTabParserContext`): parse
  `study_variable_group[n]-study_variable_refs` with duplicate detection and
  deferred resolution; defer `study_variable[n]-assay_refs` resolution for
  forward references; remove `group_ref` handling; fix a pre-existing
  `study_variable[n]-factors` switch fall-through (removed in 2.1, now ignored).
- **Validators**:
  - `StudyVariableGroupValidator`: keep parameter/description/STATO-type/
    xsd-datatype checks; resolve each `study_variable_refs` entry against the
    defined study variables (error on unknown ref); require each group to
    reference at least one study variable; once groups are defined, require
    every study variable to belong to exactly one group.
  - `StudyVariableValidator`: resolve deferred `assay_refs` against the assay
    map and error on unknown references.
- **Serializer** (`StudyVariableGroupSerializer`): emit
  `study_variable_group[n]-study_variable_refs study_variable[1]|study_variable[2]`.

### Tests

- `StudyVariableGroupValidatorTest` rewritten for the new model (11 cases).
- `StudyVariableGroupSerializerTest` extended with a `study_variable_refs` case.
- New `StudyVariableGroupParserTest` with two end-to-end fixtures:
  - `study-variable-group.mztab` — a valid file derived from the known-good gcxgc
    example that parses, resolves `study_variable_refs`, and validates with zero
    errors;
  - `example_study_variable_group.mztab` — the actual reference example from
    `HUPO-PSI/mzTab-M/examples/2.1/pending-validator/`, which validates with
    zero errors: both groups (`sex` → 2 study variables, `timepoint` → 3) parse
    and resolve their `study_variable_refs`, exercising both the new group syntax
    and the deferred `assay_refs` resolution (the file declares study variables
    before the assays they reference).

Full reactor (`api`, `io`, `validation`, `cli`, `test-utils`) builds and tests green.